### PR TITLE
add /heealth healthcheck route

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,26 @@ app.use(async (ctx, next) => {
   }
 });
 
+// Healthcheck
+app.use(async (ctx, next) => {
+  if (ctx.path !== `/health`) return next();
+
+  let valid = false;
+
+  if (ctx.headers["content-type"] === "text/plain" &&
+      ctx.request.method === "GET") {
+    valid = true;
+  }
+
+  if (valid) {
+    ctx.status = 200;
+    ctx.body = "OK";
+  } else {
+    ctx.status = 403;
+    ctx.body = "Forbidden";
+  }
+});
+
 // response body
 app.use(async ctx => {
   ctx.body = `200 OK`;


### PR DESCRIPTION
related to issue #1 

- [x] reside at /health
- [x] accept text/plain content-type
- [x] must be authenticated with the ?token= query parameter, and that token must be equal to the value provided in the AUTH_TOKEN environment variable provided in the .env file.
- [x] respond with 200 OK HTTP code to a GET request
- [x] respond with 403 Forbidden if none of the above apply